### PR TITLE
fix wrong path to deployment.dat file

### DIFF
--- a/exec/gitrepo/delayed_processing_script/mcat_final_calibration/caldip_coefficient_calculation.m
+++ b/exec/gitrepo/delayed_processing_script/mcat_final_calibration/caldip_coefficient_calculation.m
@@ -15,7 +15,7 @@ close all
 % Calculation of calibration coefficient
 % For cruise dy120: cast= [1,3,4,5,8,9,10]
 p_insitucal.cruise           =  'dy120' ;%'ar304'; %'ar304' %'dy078';%'dy053';%'pe400'; %'kn221-02'; %'pe399';       % campaign cd177 / cd170 / d304 / kn182, ...
-p_insitucal.cast             = 3;  
+p_insitucal.cast             = 8;  
 p_insitucal.depl_period      = 'osnap5'; %'osnap2'    % move1; move2; rapid 1; rapid 2
 
 % ---- parameters ----------------------------------------------------
@@ -23,6 +23,7 @@ p_insitucal.sensorselec      = 1;
 p_insitucal.sensor_id        = [332 337];  % MicroCAT ID range (in info.dat)
 p_insitucal.basedir          = pathosnap; % base directory for osnap mooring
 p_insitucal.datadir          = [p_insitucal.basedir filesep 'data']; % data directory 
+p_insitucal.coef_dir         = [pathgit '/data/moor/cal_coef/']; 
 p_insitucal.apply_offset   = 'n'; % if offset == 'y'/'n'/'i', time offset between CTD and MC 
                      % will / will not be applied / individual offsets
                      % applied  

--- a/exec/gitrepo/delayed_processing_script/mcat_final_calibration/insitu_cal_osnap2.m
+++ b/exec/gitrepo/delayed_processing_script/mcat_final_calibration/insitu_cal_osnap2.m
@@ -40,6 +40,7 @@ cruise               = p_insitucal.cruise;
 depl_period          = p_insitucal.depl_period;
 basedir              = p_insitucal.basedir;
 datadir              = p_insitucal.datadir;
+coef_dir             = p_insitucal.coef_dir;
 apply_offset         = p_insitucal.apply_offset;
 interval_move        = p_insitucal.interval_move;  
 ctd_latestart_offset = p_insitucal.ctd_latestart_offset;
@@ -182,8 +183,7 @@ end
 
 
 % Deployment Depths File Directory 
-%ein_dir     = '/users/odb/rpdmoc/rapid/data/moor/proc_calib/cal_coef/'; 
-ein_dir     = [datadir '/moor/cal_coef/']; 
+ein_dir     = coef_dir ; 
 
 %Data Files
 if strcmp('kn221-02',cruise)
@@ -258,7 +258,10 @@ instr         = instr(val);
 
 ein           = [ein_dir,depl_period,'_deploymentdepths.dat'];
 [dep,typ,ssn] = rodbload(ein,'z:instrument:serialnumber');
-								   
+if isempty(dep)
+    error(['!! MAKE sure the file ' ein ' exists or edit the filepath !!' ])    
+    return
+end		   
 % ---- CTD ----------------
 
 fprintf(1,'\n Loading CTD data ...\n')
@@ -845,7 +848,7 @@ end
 
  %plot values at MicroCAT deployment depths
 
-for i = 1 : ninst,
+for i = 1 : ninst
     subplot(1,sub,1)
     plot(mcdep(i),dt_mcdep(i),[mrkd(:,i)],'Linewidth',2,'MarkerSize',11)
     subplot(1,sub,2)


### PR DESCRIPTION
There was a bug in the script, the path to the osnap5_deploymentdepths.dat file was wrong. Therefore the pressure offset at pressure level was not displayed on figure or log. 

You can see the pressure of deployment now on the png and in the log file

<img width="829" alt="Screenshot 2021-02-01 at 15 15 04" src="https://user-images.githubusercontent.com/10154151/106469975-44fe6600-64a0-11eb-9c1a-ab1c0b2a2f1b.png">

![microcat_insitu_cal_dy120_osnap5_cast8_cond1](https://user-images.githubusercontent.com/10154151/106469885-2ac48800-64a0-11eb-820f-5f45730e90b7.png)
